### PR TITLE
Fix nautilus 4.0

### DIFF
--- a/src/nec-exif.py
+++ b/src/nec-exif.py
@@ -7,6 +7,7 @@ try:
     gi.require_version('Nautilus', '3.0')
 except ValueError:
     gi.require_version('Nautilus', '4.0')
+    from urllib.parse import unquote
 
 
 class NecExif(GObject.GObject,
@@ -87,7 +88,9 @@ class NecExif(GObject.GObject,
         return Nautilus.OperationResult.COMPLETE
 
     def do_event(self, provider, handle, closure, file_info) -> bool:
-        filename = file_info.get_location().get_path()
+        filename = file_info.get_location().get_path() \
+            if gi.get_required_version('Nautilus') == '3.0' \
+            else unquote(file_info.get_uri()[7:])
 
         try:
             MapPyExiv2(filename).to(

--- a/src/nec-exif.py
+++ b/src/nec-exif.py
@@ -3,7 +3,10 @@ import gi
 from gi.repository import Nautilus, GObject
 from pyexiv2 import ImageMetadata as from_exiv
 
-gi.require_version('Nautilus', '3.0')
+try:
+    gi.require_version('Nautilus', '3.0')
+except ValueError:
+    gi.require_version('Nautilus', '4.0')
 
 
 class NecExif(GObject.GObject,

--- a/src/nec-mediainfo.py
+++ b/src/nec-mediainfo.py
@@ -3,7 +3,10 @@ import gi
 from gi.repository import Nautilus, GObject
 from pymediainfo import MediaInfo
 
-gi.require_version('Nautilus', '3.0')
+try:
+    gi.require_version('Nautilus', '3.0')
+except ValueError:
+    gi.require_version('Nautilus', '4.0')
 
 
 class NecMediainfo(GObject.GObject,

--- a/src/nec-mediainfo.py
+++ b/src/nec-mediainfo.py
@@ -7,6 +7,7 @@ try:
     gi.require_version('Nautilus', '3.0')
 except ValueError:
     gi.require_version('Nautilus', '4.0')
+    from urllib.parse import unquote
 
 
 class NecMediainfo(GObject.GObject,
@@ -159,7 +160,9 @@ class NecMediainfo(GObject.GObject,
         return Nautilus.OperationResult.COMPLETE
 
     def do_event(self, provider, handle, closure, file_info) -> bool:
-        filename = file_info.get_location().get_path()
+        filename = file_info.get_location().get_path() \
+            if gi.get_required_version('Nautilus') == '3.0' \
+            else unquote(file_info.get_uri()[7:])
 
         try:
             MapMediaInfo(filename).to(

--- a/src/nec-pdf.py
+++ b/src/nec-pdf.py
@@ -3,8 +3,10 @@ import gi
 from gi.repository import Nautilus, GObject
 from PyPDF2 import PdfFileReader as from_pdf
 
-gi.require_version('Nautilus', '3.0')
-
+try:
+    gi.require_version('Nautilus', '3.0')
+except ValueError:
+    gi.require_version('Nautilus', '4.0')
 
 class NecPdf(GObject.GObject,
              Nautilus.ColumnProvider,

--- a/src/nec-pdf.py
+++ b/src/nec-pdf.py
@@ -7,6 +7,7 @@ try:
     gi.require_version('Nautilus', '3.0')
 except ValueError:
     gi.require_version('Nautilus', '4.0')
+    from urllib.parse import unquote
 
 class NecPdf(GObject.GObject,
              Nautilus.ColumnProvider,
@@ -84,7 +85,9 @@ class NecPdf(GObject.GObject,
         return Nautilus.OperationResult.COMPLETE
 
     def do_pypdf(self, provider, handle, closure, file_info):
-        filename = file_info.get_location().get_path()
+        filename = file_info.get_location().get_path() \
+            if gi.get_required_version('Nautilus') == '3.0' \
+            else unquote(file_info.get_uri()[7:])
 
         try:
             MapPyPDF2(filename).to(


### PR DESCRIPTION
Hi, the plugins failed for me with a ValueError:

```
nautilus_python_load_file: entered filename=nec-exif
Traceback (most recent call last):
  File "/home/commander/.local/share/nautilus-python/extensions/nec-exif.py", line 6, in <module>
    gi.require_version('Nautilus', '3.0')
  File "/usr/lib64/python3.11/site-packages/gi/__init__.py", line 117, in require_version
    raise ValueError('Namespace %s is already loaded with version %s' %
ValueError: Namespace Nautilus is already loaded with version 4.0
```

The [first commit](a0d155b46f067bf43234cd5ce7ccd9270b429317) fixes that for `gi.require_version('Nautilus', '3.0')`.

Then I got occasionally an error that is however hard to reproduce:

```
Traceback (most recent call last):
  File "/home/commander/.local/share/nautilus-python/extensions/nec-exif.py", line 90, in do_event
    filename = file_info.get_location().get_path()
               ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NautilusVFSFile' object has no attribute 'get_location'
```

I fixed this in the [second commit](b007990ce6f0049ff0c27ec4144f4d5375aa5874) by using the same method used in the nautilus-python examples https://gitlab.gnome.org/GNOME/nautilus-python/-/blob/0eaaad1a44c4fd1d7324dfb97fd8c382d59cd4e3/examples/block-size-column.py#L24

But I'm not sure if that is backward compatible to Nautilus version 3.0, so there's a conditional assignment depending on `gi.get_required_version('Nautilus') == '3.0'` and the `unquote` dependency is also only imported for Nautilus version 4.0.